### PR TITLE
Fix out of bounds read in `GFixSizeChunking` functions

### DIFF
--- a/gdelta.cpp
+++ b/gdelta.cpp
@@ -186,7 +186,7 @@ void GFixSizeChunking(unsigned char *data, int len, int begflag, int begsize,
 
     i -= WordSize;
     FPTYPE index = 0;
-    int numChunks = len - WordSize + 1;
+    int numChunks = len - WordSize;
 
     int _begsize = begflag ? begsize : 0;
     int indexMoveLength = (sizeof(FPTYPE) * 8 - mask);
@@ -221,7 +221,7 @@ void GFixSizeChunking2(unsigned char *data, int len, int begflag, int begsize,
 
     i -= WordSize;
     FPTYPE index = 0;
-    int numChunks = len - WordSize + 1;
+    int numChunks = len - WordSize - 1;
 
     int _begsize = begflag ? begsize : 0;
     int indexMoveLength = (sizeof(FPTYPE) * 8 - mask);
@@ -252,7 +252,7 @@ void GFixSizeChunking_3(unsigned char *data, int len, int begflag, int begsize,
 
     i -= WordSize;
     FPTYPE index = 0;
-    int numChunks = len - WordSize + 1;
+    int numChunks = len - WordSize - 2;
 
 
     int _begsize = begflag ? begsize : 0;
@@ -286,7 +286,7 @@ void GFixSizeChunking_4(unsigned char *data, int len, int begflag, int begsize,
 
     i -= WordSize;
     FPTYPE index = 0;
-    int numChunks = len - WordSize + 1;
+    int numChunks = len - WordSize - 3;
 
     int flag = 0;
     int _begsize = begflag ? begsize : 0;


### PR DESCRIPTION
I was testing my own command line wrapper and found this.

It seems that the `numChunks` calculation is wrong. :(

<details>

<summary>Valgrind output before this PR</summary>

```
% valgrind --leak-check=full --show-leak-kinds=all ./gdelta -v d s1.txt s2.txt sf.bin
==47078== Memcheck, a memory error detector
==47078== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==47078== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==47078== Command: ./gdelta -v d s1.txt s2.txt sf.bin
==47078== 
old_stream: read 14 bytes
new_stream: read 20 bytes
==47078== Invalid read of size 1
==47078==    at 0x129795: GFixSizeChunking_3(unsigned char*, int, int, int, unsigned int*, int, unsigned long) (gdelta.cpp:264)
==47078==    by 0x12A138: gencode(unsigned char*, unsigned int, unsigned char*, unsigned int, unsigned char**, unsigned int*) (gdelta.cpp:466)
==47078==    by 0x10F00D: main (main.cpp:96)
==47078==  Address 0x4df0ace is 0 bytes after a block of size 14 alloc'd
==47078==    at 0x483EFFF: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==47078==    by 0x11EA1E: std::__new_allocator<char>::allocate(unsigned long, void const*) (new_allocator.h:151)
==47078==    by 0x11CAF9: allocate (allocator.h:198)
==47078==    by 0x11CAF9: allocate (alloc_traits.h:482)
==47078==    by 0x11CAF9: std::_Vector_base<char, std::allocator<char> >::_M_allocate(unsigned long) (stl_vector.h:378)
==47078==    by 0x11AA8D: std::vector<char, std::allocator<char> >::_M_default_append(unsigned long) (vector.tcc:663)
==47078==    by 0x116A70: std::vector<char, std::allocator<char> >::resize(unsigned long) (stl_vector.h:1013)
==47078==    by 0x10ECA9: main (main.cpp:72)
==47078== 
==47078== Invalid read of size 1
==47078==    at 0x1297D9: GFixSizeChunking_3(unsigned char*, int, int, int, unsigned int*, int, unsigned long) (gdelta.cpp:265)
==47078==    by 0x12A138: gencode(unsigned char*, unsigned int, unsigned char*, unsigned int, unsigned char**, unsigned int*) (gdelta.cpp:466)
==47078==    by 0x10F00D: main (main.cpp:96)
==47078==  Address 0x4df0acf is 1 bytes after a block of size 14 alloc'd
==47078==    at 0x483EFFF: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==47078==    by 0x11EA1E: std::__new_allocator<char>::allocate(unsigned long, void const*) (new_allocator.h:151)
==47078==    by 0x11CAF9: allocate (allocator.h:198)
==47078==    by 0x11CAF9: allocate (alloc_traits.h:482)
==47078==    by 0x11CAF9: std::_Vector_base<char, std::allocator<char> >::_M_allocate(unsigned long) (stl_vector.h:378)
==47078==    by 0x11AA8D: std::vector<char, std::allocator<char> >::_M_default_append(unsigned long) (vector.tcc:663)
==47078==    by 0x116A70: std::vector<char, std::allocator<char> >::resize(unsigned long) (stl_vector.h:1013)
==47078==    by 0x10ECA9: main (main.cpp:72)
==47078== 
==47078== Invalid read of size 1
==47078==    at 0x12981D: GFixSizeChunking_3(unsigned char*, int, int, int, unsigned int*, int, unsigned long) (gdelta.cpp:266)
==47078==    by 0x12A138: gencode(unsigned char*, unsigned int, unsigned char*, unsigned int, unsigned char**, unsigned int*) (gdelta.cpp:466)
==47078==    by 0x10F00D: main (main.cpp:96)
==47078==  Address 0x4df0ad0 is 2 bytes after a block of size 14 alloc'd
==47078==    at 0x483EFFF: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==47078==    by 0x11EA1E: std::__new_allocator<char>::allocate(unsigned long, void const*) (new_allocator.h:151)
==47078==    by 0x11CAF9: allocate (allocator.h:198)
==47078==    by 0x11CAF9: allocate (alloc_traits.h:482)
==47078==    by 0x11CAF9: std::_Vector_base<char, std::allocator<char> >::_M_allocate(unsigned long) (stl_vector.h:378)
==47078==    by 0x11AA8D: std::vector<char, std::allocator<char> >::_M_default_append(unsigned long) (vector.tcc:663)
==47078==    by 0x116A70: std::vector<char, std::allocator<char> >::resize(unsigned long) (stl_vector.h:1013)
==47078==    by 0x10ECA9: main (main.cpp:72)
==47078== 
zstd: compressed 23 -> 32 bytes (-39.13%)
==47078== 
==47078== HEAP SUMMARY:
==47078==     in use at exit: 0 bytes in 0 blocks
==47078==   total heap usage: 32 allocs, 32 frees, 670,267 bytes allocated
==47078== 
==47078== All heap blocks were freed -- no leaks are possible
==47078== 
==47078== For lists of detected and suppressed errors, rerun with: -s
==47078== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 2 from 2)
```

</details>